### PR TITLE
Add first half of ar6 wg3 citations

### DIFF
--- a/ar6-wg-iii.bib
+++ b/ar6-wg-iii.bib
@@ -1,0 +1,198 @@
+@incollection{Lwasa2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Lwasa, S. and Seto, K.C. and Bai, X. and Blanco, H. and Gurney, K.R. and Kilkiş, S. and Lucon, O. and Murakami, J. and Pan, J. and Sharifi, A. and Yamagata, Y.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {8},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Urban systems and other settlements Supplementary Material}},
+year = {2022}
+}
+@incollection{Lwasa2022a,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Lwasa, S. and Seto, K.C. and Bai, X. and Blanco, H. and Gurney, K.R. and Kilkiş, S. and Lucon, O. and Murakami, J. and Pan, J. and Sharifi, A. and Yamagata, Y.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {8},
+doi = {10.1017/9781009157926.010},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Urban systems and other settlements.}},
+year = {2022}
+}
+@dataset{byers_edward_2022_5886912,
+author = {Byers, Edward and Krey, Volker and Kriegler, Elmar and Riahi, Keywan and Schaeffer, Roberto and Kikstra, Jarmo and Lamboll, Robin and Nicholls, Zebedee and Sandstad, Marit and Smith, Chris and van der Wijst, Kaj and Lecocq, Franck and Portugal-Pereira, Joana and Saheb, Yamina and Stromann, Anders and Winkler, Harald and Auer, Cornelia and Brutschin, Elina and Lepault, Claire and M{\"{u}}ller-Casseres, Eduardo and Gidden, Matthew and Huppmann, Daniel and Kolp, Peter and Marangoni, Giacomo and Werning, Michaela and Calvin, Katherine and Guivarch, Celine and Hasegawa, Tomoko and Peters, Glen and Steinberger, Julia and Tavoni, Massimo and van Vuuren, Detlef and {Al -Khourdajie}, Alaa and Forster, Piers and Lewis, Jared and Meinshausen, Malte and Rogelj, Joeri and Samset, Bjorn and Skeie, Ragnhild},
+doi = {10.5281/zenodo.5886912},
+month = {apr},
+publisher = {Zenodo},
+title = {{AR6 Scenarios Database}},
+url = {https://doi.org/10.5281/zenodo.5886912},
+year = {2022}
+}
+@incollection{Nabuurs2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Nabuurs, G-J. and Mrabet, R. and Hatab, A. Abu and Bustamante, M. and Clark, H. and Havl{\'{i}}k, P. and House, J. and Mbow, C. and Ninan, K.N. and Popp, A. and Roe, S. and Sohngen, B. and Towprayoo, S.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {7},
+doi = {10.1017/9781009157926.009},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Agriculture, Forestry and Other Land Uses (AFOLU)}},
+year = {2022}
+}
+@incollection{IPCC2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {IPCC},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {Annex II},
+doi = {10.1017/9781009157926.022},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Annex III: Scenarios and modelling methods [Guivarch, C., E. Kriegler, J. Portugal-Pereira, V. Bosetti, J. Edmonds, M. Fischedick, P. Havl{\'{i}}k, P. Jaramillo, V. Krey, F. Lecocq, A. Lucena, M. Meinshausen, S. Mirasgedis, B. O'Neill, G.P. Peters, J. Rogelj, S}},
+year = {2022}
+}
+@incollection{IPCC2022a,
+address = {Cambridge, UK and New York, NY, USA},
+author = {IPCC},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+doi = {10.1017/9781009157926.021},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Annex II: Definitions, Units and Conventions [Al Khourdajie, A., R. van Diemen, W.F. Lamb, M. Pathak, A. Reisinger, S. de la Rue du Can, J. Skea, R. Slade, S. Some, L. Steg (eds)]}},
+year = {2022}
+}
+@incollection{IPCC2022b,
+address = {Cambridge, UK and New York, NY, USA},
+author = {IPCC},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {Annex I},
+doi = {10.1017/9781009157926.020},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Annex I: Glossary [van Diemen, R., J.B.R. Matthews, V. M{\"{o}}ller, J.S. Fuglestvedt, V. Masson-Delmotte, C. M{\'{e}}ndez, A. Reisinger, S. Semenov (eds)].}},
+year = {2022}
+}
+@incollection{Clarke2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Clarke, L. and Wei, Y.-M. and Navarro, A. De La Vega and Garg, A. and Hahmann, A.N. and Khennas, S. and Azevedo, I.M.L. and L{\"{o}}schel, A. and Singh, A.K. and Steg, L. and Strbac, G. and Wada, K.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {6},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Energy Systems Supplementary Material}},
+year = {2022}
+}
+@incollection{Clarke2022a,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Clarke, L. and Wei, Y.-M. and Navarro, A. De La Vega and Garg, A. and Hahmann, A.N. and Khennas, S. and Azevedo, I.M.L. and L{\"{o}}schel, A. and Singh, A.K. and Steg, L. and Strbac, G. and Wada, K.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {6},
+doi = {10.1017/9781009157926.008},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Energy Systems}},
+year = {2022}
+}
+@incollection{Creutzig2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Creutzig, F. and Roy, J. and Devine-Wright, P. and D{\'{i}}az-Jos{\'{e}}, J. and Geels, F.W. and Grubler, A. and Maϊzi, N. and Masanet, E. and Mulugetta, Y. and Onyige, C.D. and Perkins, P.E. and Sanches-Pereira, A. and Weber, E.U.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {5},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Demand, services and social aspects of mitigation Supplementary Material}},
+year = {2022}
+}
+@incollection{Creutzig2022a,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Creutzig, F. and Roy, J. and Devine-Wright, P. and D{\'{i}}az-Jos{\'{e}}, J. and Geels, F.W. and Grubler, A. and Maϊzi, N. and Masanet, E. and Mulugetta, Y. and Onyige, C.D. and Perkins, P.E. and Sanches-Pereira, A. and Weber, E.U.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {5},
+doi = {10.1017/9781009157926.007},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Demand, services and social aspects of mitigation.}},
+year = {2022}
+}
+@incollection{Lecocq2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Lecocq, F. and Winkler, H. and Daka, J.P. and Fu, S. and Gerber, J.S. and Kartha, S. and Krey, V. and Lofgren, H. and Masui, T. and Mathur, R. and Portugal-Pereira, J. and Sovacool, B. K. and Vilari{\~{n}}o, M. V. and Zho, N.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {4},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Mitigation and development pathways in the near- to mid-term Supplementary Material.}},
+year = {2022}
+}
+@incollection{Lecocq2022a,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Lecocq, F. and Winkler, H. and Daka, J.P. and Fu, S. and Gerber, J.S. and Kartha, S. and Krey, V. and Lofgren, H. and Masui, T. and Mathur, R. and Portugal-Pereira, J. and Sovacool, B. K. and Vilari{\~{n}}o, M. V. and Zho, N.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {4},
+doi = {10.1017/9781009157926.006},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Mitigation and development pathways in the near- to mid-term.}},
+year = {2022}
+}
+@incollection{Riahi2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Riahi, K. and Schaeffer, R. and Arango, J. and Calvin, K. and Guivarch, C. and Hasegawa, T. and Jiang, K. and Kriegler, E. and Matthews, R. and Peters, G.P. and Rao, A. and Robertson, S. and Sebbit, A.M. and Steinberger, J. and Tavoni, M. and {Van Vuuren}, D.P.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {3},
+doi = {10.1017/9781009157926.005},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Mitigation pathways compatible with long-term goals.}},
+year = {2022}
+}
+@incollection{Dhakal2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Dhakal, S. and Minx, J.C. and Toth, F.L. and Abdel-Aziz, A. and {Figueroa Meza}, M.J. and Hubacek, K. and Jonckheere, I.G.C. and Kim, Yong-Gun and Nemet, G.F. and Pachauri, S. and Tan, X.C. and Wiedmann, T.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {2},
+doi = {10.1017/9781009157926.004},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Emissions Trends and Drivers}},
+year = {2022}
+}
+@incollection{Grubb2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Grubb, M. and Okereke, C. and Arima, J. and Bosetti, V. and Chen, Y. and Edmonds, J. and Gupta, S. and K{\"{o}}berle, A. and Kverndokk, S. and Malik, A. and Sulistiawati, L.},
+booktitle = {IPCC, 2022: Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+chapter = {1},
+doi = {10.1017/9781009157926.003},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Introduction and Framing}},
+year = {2022}
+}
+@incollection{Pathak2022,
+address = {Cambridge, UK and New York, NY, USA},
+author = {Pathak, M. and Slade, R. and Shukla, P.R. and Skea, J. and Pichs-Madruga, R. and {\"{U}}rge-Vorsatz, D.},
+booktitle = {Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+doi = {10.1017/9781009157926.002},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Technical Summary}},
+year = {2022}
+}
+@incollection{IPCC2022c,
+address = {Cambridge, UK and New York, NY, USA},
+author = {IPCC},
+booktitle = {Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+doi = {10.1017/9781009157926.001},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Summary for Policymakers}},
+year = {2022}
+}
+@book{IPCC2022d,
+address = {Cambridge, UK and New York, NY, USA},
+author = {IPCC},
+doi = {10.1017/9781009157926},
+editor = {Shukla, P.R. and Skea, J. and Slade, R. and Khourdajie, A. Al and van Diemen, R. and McCollum, D. and Pathak, M. and Some, S. and Vyas, P. and Fradera, R. and Belkacemi, M. and Hasija, A. and Lisboa, G. and Luz, S. and Malley, J.},
+publisher = {Cambridge University Press},
+title = {{Climate Change 2022: Mitigation of Climate Change. Contribution of Working Group III to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change}},
+year = {2022}
+}


### PR DESCRIPTION
Makes a first start of adding WG3 citations.

Has full report, SPM, TM, Chapters 1-8, and Annex I-III.

Still missing everything from Chapter 9 to Chapter 17 SM.