### PR TITLE
Adding far-wg-iii (#52)

### DIFF
--- a/far-wg-iii.bib
+++ b/far-wg-iii.bib
@@ -1,0 +1,227 @@
+# Full Report
+
+@book{IPCC_1990_WGIII,
+  address = {Cambridge, UK},
+  author = {IPCC},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  pages = {332},
+  publisher = {Cambridge University Press},
+  title = {Climate Change: The IPCC Response Strategies. Report Prepared for the IPCC by Working Group 3},
+  type = {Book},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_full_report.pdf},
+  year = {1990},
+}
+
+# Policymakers Summary
+
+@incollection{IPCC_1990_WGIII_PS,
+  title = {Policymakers Summary},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {SPM},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_spm.pdf},
+  year = {1990},
+  author = {IPCC},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {17-60},
+}
+
+# IPCC Response Strategies Working Group Reports
+
+# Introduction
+
+@incollection{IPCC_1990_WGIII_Ch_1,
+  title = {Introduction},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {1},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_01.pdf},
+  year = {1990},
+  author = {IPCC},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {61-68},
+}
+
+# Emissions Scenarios
+
+@incollection{IPCC_1990_WGIII_Ch_2,
+  title = {Emissions Scenarios},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {2},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_02.pdf},
+  year = {1990},
+  author = {Tirpak, D. and Vellinga, P.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {69-102},
+}
+
+# Subgroup Reports
+
+# Energy and Industry
+
+@incollection{IPCC_1990_WGIII_Ch_3,
+  title = {Energy and Industry},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {3},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_03.pdf},
+  year = {1990},
+  author = {Yokobori, K. and Xie, Shao-Xiong},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {105-132},
+}
+
+# Agriculture, Forestry, and Other Human Activities
+
+@incollection{IPCC_1990_WGIII_Ch_4,
+  title = {Agriculture, Forestry, and Other Human Activities},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {4},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_04.pdf},
+  year = {1990},
+  author = {Kupfer, D. and Karimanzira, R.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {133-187},
+}
+
+# Coastal Zone Management
+
+@incollection{IPCC_1990_WGIII_Ch_5,
+  title = {Coastal Zone Management},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {5},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_05.pdf},
+  year = {1990},
+  author = {Gilbert, J. and Vellinga, P.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {189-219},
+}
+
+# Resource Use and Management
+
+@incollection{IPCC_1990_WGIII_Ch_6,
+  title = {Resource Use and Management},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {6},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_06.pdf},
+  year = {1990},
+  author = {Pentland, R. and Theys, J. and Abrol, I.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {221-265},
+}
+
+# Implementation Measures
+
+# Public Education and Information Mechanisms
+
+@incollection{IPCC_1990_WGIII_Ch_7,
+  title = {Public Education and Information Mechanisms},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {7},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_07.pdf},
+  year = {1990},
+  author = {Evans, G. and Luo, Ji-Bin},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {269-277},
+}
+
+# Technology Development and Transfer
+
+@incollection{IPCC_1990_WGIII_Ch_8,
+  title = {Technology Development and Transfer},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {8},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_08.pdf},
+  year = {1990},
+  author = {{Madhava Sarma}, K. and Haraguchi, K.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {279-287},
+}
+
+# Economic (Market) Measures
+
+@incollection{IPCC_1990_WGIII_Ch_9,
+  title = {Economic (Market) Measures},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {9},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_09.pdf},
+  year = {1990},
+  author = {Tilley, J. and Gilbert, J.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {289-304},
+}
+
+# Financial Mechanisms
+
+@incollection{IPCC_1990_WGIII_Ch_10,
+  title = {Financial Mechanisms},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {10},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_10.pdf},
+  year = {1990},
+  author = {Oppenaeu, J. and Vellinga, P. and Ibrahim, A.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {305-315},
+}
+
+# Legal and Institutional Mechanisms
+
+@incollection{IPCC_1990_WGIII_Ch_11,
+  title = {Legal and Institutional Mechanisms},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {11},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_chapter_11.pdf},
+  year = {1990},
+  author = {Rochon, R. and Attard, D. and Beetham, R.},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {317-328},
+}
+
+# Appendix 1 List of Acronyms and Chemical Symbols
+
+@incollection{IPCC_1990_WGIII_Ch_Appendix1,
+  title = {Appendix 1: List of Acronyms and Chemical Symbols},
+  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  chapter = {Appendix1},
+  url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_acronyms_chemical_symbols.pdf},
+  year = {1990},
+  author = {IPCC},
+  editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
+  type = {Book Section},
+  pages = {329-330},
+}

--- a/far-wg-iii.bib
+++ b/far-wg-iii.bib
@@ -6,7 +6,7 @@
   editor = {Bernthal, {Frederick M.} and Dowdeswell, E. and Luo, J. and Attard, D. and Vellinga, P. and Karimanzira, R.},
   pages = {332},
   publisher = {Cambridge University Press},
-  title = {Climate Change: The IPCC Response Strategies. Report Prepared for the IPCC by Working Group 3},
+  title = {Climate Change: The IPCC Response Strategies},
   type = {Book},
   url = {https://www.ipcc.ch/site/assets/uploads/2018/03/ipcc_far_wg_III_full_report.pdf},
   year = {1990},
@@ -16,7 +16,7 @@
 
 @incollection{IPCC_1990_WGIII_PS,
   title = {Policymakers Summary},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {SPM},
@@ -34,7 +34,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_1,
   title = {Introduction},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {1},
@@ -50,7 +50,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_2,
   title = {Emissions Scenarios},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {2},
@@ -68,7 +68,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_3,
   title = {Energy and Industry},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {3},
@@ -84,7 +84,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_4,
   title = {Agriculture, Forestry, and Other Human Activities},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {4},
@@ -100,7 +100,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_5,
   title = {Coastal Zone Management},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {5},
@@ -116,7 +116,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_6,
   title = {Resource Use and Management},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {6},
@@ -134,7 +134,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_7,
   title = {Public Education and Information Mechanisms},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {7},
@@ -150,7 +150,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_8,
   title = {Technology Development and Transfer},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {8},
@@ -166,7 +166,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_9,
   title = {Economic (Market) Measures},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {9},
@@ -182,7 +182,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_10,
   title = {Financial Mechanisms},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {10},
@@ -198,7 +198,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_11,
   title = {Legal and Institutional Mechanisms},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {11},
@@ -214,7 +214,7 @@
 
 @incollection{IPCC_1990_WGIII_Ch_Appendix1,
   title = {Appendix 1: List of Acronyms and Chemical Symbols},
-  booktitle = {Climate Change: The IPCC Response Strategies. Report Prepared for IPCC by Working Group 3},
+  booktitle = {Climate Change: The IPCC Response Strategies},
   publisher = {Cambridge University Press},
   address = {Cambridge, UK},
   chapter = {Appendix1},


### PR DESCRIPTION
Add [FAR Climate Change: The IPCC Response Strategies](https://www.ipcc.ch/report/ar1/wg3/) - this has a number of scenario-relevant sections I am keen to cite.

I have
- [x] `far-wg-iii.bib` - Added all sections, authors, and URLs
- [ ] Run `Makefile` (`bibtex2html` over updated `*.bib` files)

Close #52