### PR TITLE
add TAR Guidance Papers 2000 (#54)

### DIFF
--- a/tar-guidancepapers2000.bib
+++ b/tar-guidancepapers2000.bib
@@ -74,7 +74,7 @@
 
 # Development, Equity and Sustainability (DES) In The Context Of Climate Change
 
-@incollection{IPCC_2000_Guides_Decision,
+@incollection{IPCC_2000_Guides_DES,
   address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
   author = {Munasinghe, Mohan},
   booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
@@ -91,7 +91,7 @@
 
 # Summary of the IPCC Expert Meeting on Development, Equity and Sustainability held in Colombo, Sri Lanka, 27-29 April 1999
 
-@incollection{IPCC_2000_Guides_DESMeeting,
+@incollection{IPCC_2000_Guides_DESMeeting1,
   address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
   author = {Munasinghe, Mohan and Swart, Rob},
   booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
@@ -106,7 +106,7 @@
 
 # Short Report of IPCC Costing Issues Expert Meeting in Tokyo, Japan, 29 June-1 July 1999
 
-@incollection{IPCC_2000_Guides_DESMeeting,
+@incollection{IPCC_2000_Guides_CostIssuesMeeting,
   address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
   author = {Pachauri, {Rajendra K.} and Taniguchi, Tomihiro},
   booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
@@ -121,7 +121,7 @@
 
 # Second Regional Expert Meeting on "Development, Equity and Sustainability" in Havana, Cuba, 23-25 February 2000
 
-@incollection{IPCC_2000_Guides_DESMeeting,
+@incollection{IPCC_2000_Guides_DESMeeting2,
   address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
   author = {Pichs, Ramon and Leary, Neil and Swart, Rob},
   booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},

--- a/tar-guidancepapers2000.bib
+++ b/tar-guidancepapers2000.bib
@@ -1,0 +1,135 @@
+@book{IPCC_2000_Guides,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {IPCC},
+  isbn = {ISBN 4-9980908-0-1},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {142},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  type = {Book},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  howpublished = {\url{https://www.ipcc.ch/report/ar3/syr/}},
+  year = {2000},
+}
+
+# User's Guide
+
+@incollection{IPCC_2000_Guides_User,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Taniguchi, Tomihiro and Tanaka, Kanako},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {1-14},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {User's Guide for Cross-Cutting Issues Guidance Papers},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Costing Methodologies
+
+@incollection{IPCC_2000_Guides_Costing,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Markandya, Anil and Halsnaes, Kirsten},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {15-31},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Costing Methodologies},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Uncertainties in the IPCC TAR: Recommendations To Lead Authors For More Consistent Assessment and Reporting
+
+@incollection{IPCC_2000_Guides_Uncertainties,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Moss, {Richard H.} and Schneider, {Stephen H.}},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {33-51},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Uncertainties in the IPCC TAR: Recommendations To Lead Authors For More Consistent Assessment and Reporting},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Decision Analysis Frameworks in TAR
+
+@incollection{IPCC_2000_Guides_Decision,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Toth, {Ferenc L.}},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {53-68},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Decision Analysis Frameworks in TAR},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Development, Equity and Sustainability (DES) In The Context Of Climate Change
+
+@incollection{IPCC_2000_Guides_Decision,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Munasinghe, Mohan},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {69-110},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Development, Equity and Sustainability (DES) In The Context Of Climate Change},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Meeting summaries
+
+# Summary of the IPCC Expert Meeting on Development, Equity and Sustainability held in Colombo, Sri Lanka, 27-29 April 1999
+
+@incollection{IPCC_2000_Guides_DESMeeting,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Munasinghe, Mohan and Swart, Rob},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {111-119},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Summary of the IPCC Expert Meeting on Development, Equity and Sustainability held in Colombo, Sri Lanka, 27-29 April 1999},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Short Report of IPCC Costing Issues Expert Meeting in Tokyo, Japan, 29 June-1 July 1999
+
+@incollection{IPCC_2000_Guides_DESMeeting,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Pachauri, {Rajendra K.} and Taniguchi, Tomihiro},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {121-132},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Short Report of IPCC Costing Issues Expert Meeting in Tokyo, Japan, 29 June-1 July 1999},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}
+
+# Second Regional Expert Meeting on "Development, Equity and Sustainability" in Havana, Cuba, 23-25 February 2000
+
+@incollection{IPCC_2000_Guides_DESMeeting,
+  address = {Intergovernmental Panel on Climate Change (IPCC), C/o World Meteorological Organization},
+  author = {Pichs, Ramon and Leary, Neil and Swart, Rob},
+  booktitle = {Guidance Papers on the Cross-Cutting Issues of the Third Assessment Report of the IPCC. Report Prepared for IPCC by Working Groups II and III},
+  editor = {Pachauri, Rajendra and Taniguchi, Tomihiro and Tanaka, Kanako},
+  pages = {133-138},
+  publisher = {Global Industrial and Social Progress Research Institute (GISPRI)},
+  title = {Second Regional Expert Meeting on "Development, Equity and Sustainability" in Havana, Cuba, 23-25 February 2000},
+  type = {Book Section},
+  url = {https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf},
+  year = {2000},
+}


### PR DESCRIPTION
Add [Guidance Papers on the Cross Cutting Issues of the Third Assessment Report of the IPCC](https://archive.ipcc.ch/pdf/supporting-material/guidance-papers-3rd-assessment.pdf)

I have
- [x] `tar-guidancepapers2000.bib` - Added all authors, and ISBN
- [ ] Run `Makefile` (`bibtex2html` over updated `*.bib` files)

Close #54 